### PR TITLE
Update gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,42 +9,42 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (8.2.5)
+    byebug (9.0.6)
     coderay (1.1.1)
-    denv (0.2.4)
-    esa (1.5.0)
+    denv (0.2.5)
+    esa (1.8.0)
       faraday (~> 0.9)
       faraday_middleware
       mime-types (~> 2.6)
       multi_xml (~> 0.5.5)
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.10.0)
-      faraday (>= 0.7.4, < 0.10)
-    json (1.8.3)
+    faraday_middleware (0.12.0)
+      faraday (>= 0.7.4, < 1.0)
+    json (2.1.0)
     method_source (0.8.2)
-    mime-types (2.99.1)
+    mime-types (2.99.3)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.3.0)
-      byebug (~> 8.0)
+    pry-byebug (3.4.2)
+      byebug (~> 9.0)
       pry (~> 0.10)
-    rake (10.5.0)
+    rake (12.0.0)
     slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.10)
+  bundler (~> 1.15)
   esapad!
   pry
   pry-byebug
-  rake (~> 10.0)
+  rake (~> 12.0)
 
 BUNDLED WITH
-   1.11.2
+   1.15.3

--- a/esapad.gemspec
+++ b/esapad.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json"
   spec.add_dependency "denv"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
Update gems, especially `json(1.8.3)` will fail to install with ruby 2.4 💎 