### PR TITLE
Add env value for tweaking parameter

### DIFF
--- a/lib/esapad.rb
+++ b/lib/esapad.rb
@@ -8,6 +8,8 @@ require "pry"
 Denv.load
 
 class Esapad
+  DEFAULT_PER_PAGE = 20
+
   def initialize
     @client = Esa::Client.new(access_token: ENV["ESA_ACCESS_TOKEN"], current_team: ENV["ESA_TEAM"])
   end
@@ -43,7 +45,7 @@ class Esapad
       when "stock"
         "wip:false -#{blog_query} -body:RECENTLY-UPDATED-POSTS"
     end
-    @client.posts(q: query).body["posts"]
+    @client.posts(q: query, per_page: per_page).body["posts"]
   end
 
   def generate_updated_md(kind)
@@ -102,5 +104,9 @@ class Esapad
       /<!-- RECENTLY-LIKED-POSTS-START -->(.+)<!-- RECENTLY-LIKED-POSTS-END -->/m,
       "<!-- RECENTLY-LIKED-POSTS-START -->#{updated_md}<!-- RECENTLY-LIKED-POSTS-END -->"
     )
+  end
+
+  def per_page
+    @per_page ||= ENV["PER_PAGE"] || DEFAULT_PER_PAGE
   end
 end

--- a/lib/esapad.rb
+++ b/lib/esapad.rb
@@ -29,7 +29,8 @@ class Esapad
 
     if target_page_md != target_page.body["body_md"]
       target_page_md = replace_updated_time(target_page_md)
-      @client.update_post(target_page_id, body_md: target_page_md, updated_by: "esa_bot")
+      message = skip_notice? ? "[skip notice]" : ""
+      @client.update_post(target_page_id, body_md: target_page_md, updated_by: "esa_bot", message: message)
       puts "Updated: #{ target_page.body["url"] }"
     end
   end
@@ -104,6 +105,10 @@ class Esapad
       /<!-- RECENTLY-LIKED-POSTS-START -->(.+)<!-- RECENTLY-LIKED-POSTS-END -->/m,
       "<!-- RECENTLY-LIKED-POSTS-START -->#{updated_md}<!-- RECENTLY-LIKED-POSTS-END -->"
     )
+  end
+
+  def skip_notice?
+    @skip_notice ||= !!ENV["SKIP_NOTICE"]
   end
 
   def per_page


### PR DESCRIPTION
Add 2 env values for tweaking request parameter :)

- `ENV['PER_PAGE']` : Define number of contents at one request.
- `ENV['SKIP_NOTICE']` : If you wouldn't like to notice to update, you can run shell with `SKIP_NOTICE=1`.

FYI: @hogelog 