### PR TITLE
Remove unnecessary break

### DIFF
--- a/lib/esapad.rb
+++ b/lib/esapad.rb
@@ -53,7 +53,6 @@ class Esapad
     posts = fetch_updated_pages(kind)
     posts.map {|post|
       <<-MARKDOWN
-
       <li>
         <a href="#{ post["url"] }">#{ post["full_name"] }</a>
         <div class="recently-updated-posts-metadata" style="font-size: 90%;">
@@ -75,7 +74,6 @@ class Esapad
       sort_by {|post| -Time.parse(post["updated_at"]).to_i }.
       map {|post|
         <<-MARKDOWN
-
         <li>
           <a href="#{ post["url"] }">#{ post["full_name"] }</a>
           <span class="recently-liked-posts-metadata" style="font-size: 90%;"> :star: #{ post["stargazers_count"] } </span>


### PR DESCRIPTION
Because esa's markdown engine was changed, there was a problem that newline immediately after tag was interpreted as markdown notation. 

This PR solves this problem by deleting newline.

ref. https://docs.esa.io/posts/290#HTML%E5%86%85%E3%81%AEMarkdown%E8%A8%98%E8%BF%B0

FYI: @hogelog